### PR TITLE
Support for health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ Soon enough you will be writing code of your integration logic. Get in touch at 
 
 ## Organization
 
--   `lib/connector` contains the core Fusebit OAuth Connector logic that manages authentication to an API protected with OAuth access tokens in a multi-tenant system.
--   `lib/manager` contains the Fusebit OAuth Connector Manager logic which supports the install/uninstall/configure operations for the connector.
--   `lib/manager/template` contains a template of a Fusebit Function that exposes the Fusebit OAuth Connector interface. As a developer, you will be spending most of your time focusing on adding your integration logic to [VendorOAuthConnector.js](https://github.com/fusebit/oauth-connector/blob/main/lib/manager/template/VendorOAuthConnector.js).
--   `fusebit` contains a template of a Fusebit Function that exposes the Fusebit OAuth Connector Manager interface.
+- `lib/connector` contains the core Fusebit OAuth Connector logic that manages authentication to an API protected with OAuth access tokens in a multi-tenant system.
+- `lib/manager` contains the Fusebit OAuth Connector Manager logic which supports the install/uninstall/configure operations for the connector.
+- `lib/manager/template` contains a template of a Fusebit Function that exposes the Fusebit OAuth Connector interface. As a developer, you will be spending most of your time focusing on adding your integration logic to [VendorOAuthConnector.js](https://github.com/fusebit/oauth-connector/blob/main/lib/manager/template/VendorOAuthConnector.js).
+- `fusebit` contains a template of a Fusebit Function that exposes the Fusebit OAuth Connector Manager interface.
 
 ## Running tests
 
 Here are a few things you need to know before running tests:
 
--   You must have access to a [Fusebit](https://fusebit.io) subscription.
--   You must have the [Fusebit CLI](https://fusebit.io/docs/reference/fusebit-cli/) installed.
--   You must have a Fusebit CLI profile configured with an account ID and subscription ID, and sufficient permissions to manage all functions and all storage on that subscription.
--   The test will create and remove functions in randomly named boundary in the subscription.
--   The test will create and remove storage objects in randomly named storage ID in the subscription.
+- You must have access to a [Fusebit](https://fusebit.io) subscription.
+- You must have the [Fusebit CLI](https://fusebit.io/docs/reference/fusebit-cli/) installed.
+- You must have a Fusebit CLI profile configured with an account ID and subscription ID, and sufficient permissions to manage all functions and all storage on that subscription.
+- The test will create and remove functions in randomly named boundary in the subscription.
+- The test will create and remove storage objects in randomly named storage ID in the subscription.
 
 To run the tests, set the `FUSE_PROFILE` environment variable to the Fusebit CLI profile name to use:
 
@@ -47,9 +47,10 @@ debug=1 FUSE_PROFILE={profile-name} npm test
 
 ### v1.1.0
 
--   Support for composing multiple OAuth connectors to create complex integrations involving several systems.
--   Update @fusebit/add-on-sdk dependency to 3.1.0, refactor creation of Express router.
+- Support for composing multiple OAuth connectors to create complex integrations involving several systems.
+- Support for health check
+- Update @fusebit/add-on-sdk dependency to 3.1.0, refactor creation of Express router.
 
 ### v1.0.0
 
--   Initial implementation.
+- Initial implementation.

--- a/fusebit/package.json
+++ b/fusebit/package.json
@@ -1,8 +1,8 @@
 {
-    "engines": {
-        "node": "10"
-    },
-    "dependencies": {
-        "@fusebit/oauth-connector": "1.1.0-pre-1"
-    }
+  "engines": {
+    "node": "10"
+  },
+  "dependencies": {
+    "@fusebit/oauth-connector": "1.1.0"
+  }
 }

--- a/lib/connector/OAuthConnector.js
+++ b/lib/connector/OAuthConnector.js
@@ -272,11 +272,11 @@ class OAuthConnector {
    * Deletes user context from storage.
    * @param {FusebitContext} fusebitContext The Fusebit context
    * @param {string} vendorUserId The vendor user id
-   * @param {string} foreignVendorId If specified, vendorUserId represents the identity of the user in another system.
-   * The foreignVendorId must correspond to an entry in userContext.foreignOAuthIdentities.
+   * @param {string} vendorId If specified, vendorUserId represents the identity of the user in another system.
+   * The vendorId must correspond to an entry in userContext.foreignOAuthIdentities.
    */
-  async deleteUser(fusebitContext, vendorUserId, foreignVendorId) {
-    const userContext = await this.getUser(fusebitContext, vendorUserId, foreignVendorId);
+  async deleteUser(fusebitContext, vendorUserId, vendorId) {
+    const userContext = await this.getUser(fusebitContext, vendorUserId, vendorId);
     if (userContext && userContext.foreignOAuthIdentities) {
       for (let fvId in userContext.foreignOAuthIdentities) {
         await fusebitContext.storage.delete(
@@ -284,7 +284,17 @@ class OAuthConnector {
         );
       }
     }
-    return fusebitContext.storage.delete(this.getStorageIdForVendorUser(userContext.vendorUserId));
+    return userContext && fusebitContext.storage.delete(this.getStorageIdForVendorUser(userContext.vendorUserId));
+  }
+
+  /**
+   * Gets the health status of the user
+   * @param {FusebitContext} fusebitContext The Fusebit context of the request
+   * @param {*} userContext The user context representing the vendor's user. Contains vendorToken and vendorUserProfile, representing responses
+   * from getAccessToken and getUserProfile, respectively.
+   */
+  async getHealth(fusebitContext, userContext) {
+    return { status: 200 };
   }
 
   /**

--- a/lib/connector/OAuthConnector.js
+++ b/lib/connector/OAuthConnector.js
@@ -332,7 +332,8 @@ class OAuthConnector {
     const ensureLocalAccessToken = async () => {
       if (
         userContext.vendorToken.access_token &&
-        userContext.vendorToken.expires_at > Date.now() + this.accessTokenExpirationBuffer
+        (userContext.vendorToken.expires_at === undefined ||
+          userContext.vendorToken.expires_at > Date.now() + this.accessTokenExpirationBuffer)
       ) {
         Sdk.debug('RETURNING CURRENT ACCESS TOKEN FOR USER', userContext.vendorUserId);
         return userContext.vendorToken;
@@ -368,6 +369,9 @@ class OAuthConnector {
           }
         }
       }
+      Sdk.debug('REFRESH TOKEN ERROR: ACCESS TOKEN EXPIRED BUT REFRESH TOKEN ABSENT, DELETING USER');
+      await this.deleteUser(fusebitContext, userContext.vendorUserId);
+      throw new Error(`Access token is exired and cannot be refreshed because the refresh token is not present.`);
     };
 
     const waitForRefreshedAccessToken = async (count, backoff) => {

--- a/lib/connector/app.js
+++ b/lib/connector/app.js
@@ -13,18 +13,25 @@ const httpError = (res, status, message) => {
 exports.createApp = (connector) => {
   const app = require('express')();
   const settingsManager = Sdk.createSettingsManager(createConfigure(connector));
-  const authorizeVendorUserOperation = connector.authorize({
-    action: 'function:execute',
-    resourceFactory: (req) =>
-      `/account/${req.fusebit.accountId}/subscription/${req.fusebit.subscriptionId}/boundary/${
-        req.fusebit.boundaryId
-      }/function/${req.fusebit.functionId}/user/${encodeURIComponent(req.params.vendorUserId)}/`,
-  });
-  const authorizeForeignVendorUserOperation = connector.authorize({
-    action: 'function:execute',
-    resourceFactory: (req) =>
-      `/account/${req.fusebit.accountId}/subscription/${req.fusebit.subscriptionId}/boundary/${req.fusebit.boundaryId}/function/${req.fusebit.functionId}/foreign-user/`,
-  });
+
+  const createUserSubresource = (req, subresource) =>
+    req.params.vendorId
+      ? `/account/${req.fusebit.accountId}/subscription/${req.fusebit.subscriptionId}/boundary/${
+          req.fusebit.boundaryId
+        }/function/${req.fusebit.functionId}/foreign-user/${encodeURIComponent(
+          req.params.vendorId
+        )}/${encodeURIComponent(req.params.vendorUserId)}/${(subresource && subresource + '/') || ''}`
+      : `/account/${req.fusebit.accountId}/subscription/${req.fusebit.subscriptionId}/boundary/${
+          req.fusebit.boundaryId
+        }/function/${req.fusebit.functionId}/user/${encodeURIComponent(req.params.vendorUserId)}/${
+          (subresource && subresource + '/') || ''
+        }`;
+
+  const authorizeUserOperation = (subresource) =>
+    connector.authorize({
+      action: 'function:execute',
+      resourceFactory: (req) => createUserSubresource(req, subresource),
+    });
 
   // Called from the connector manager to clean up all subordinate artifacts of this connector
   app.delete(
@@ -40,6 +47,80 @@ exports.createApp = (connector) => {
     }
   );
 
+  const lookupUser = async (req, res, next) => {
+    // req.params.vendorId may be undefined
+    req.params.userContext = await connector.getUser(req.fusebit, req.params.vendorUserId, req.params.vendorId);
+    if (!req.params.userContext) {
+      return httpError(
+        res,
+        404,
+        req.params.vendorId
+          ? `User with vendor ID '${req.params.vendorId}' and user ID '${req.params.vendorUserId} not found.`
+          : `User with user ID '${req.params.vendorUserId} not found.`
+      );
+    }
+    next();
+  };
+
+  // Get user context of the user identified with vendor user ID, or with foreign vendor ID and foreign user ID
+  app.get(
+    ['/user/:vendorUserId', '/foreign-user/:vendorId/:vendorUserId'],
+    authorizeUserOperation(),
+    lookupUser,
+    async (req, res) => res.json(req.params.userContext)
+  );
+
+  // Get health of the user identified with vendor user ID, or with foreign vendor ID and foreign user ID
+  app.get(
+    ['/user/:vendorUserId/health', '/foreign-user/:vendorId/:vendorUserId/health'],
+    authorizeUserOperation('health'),
+    lookupUser,
+    async (req, res) => {
+      let response;
+      try {
+        response = (await connector.getHealth(req.fusebit, req.params.userContext)) || { status: 200 };
+      } catch (e) {
+        Sdk.debug(
+          'ERROR OBTAINING USER HEALTH',
+          req.params.vendorId,
+          req.params.vendorUserId,
+          e.stack || e.message || e
+        );
+        return httpError(res, 500, `Error obtaining user health information: ${e.message}`);
+      }
+      res.status(response.status || 200);
+      response.body ? res.json(response.body) : res.end();
+    }
+  );
+
+  // Get current access token for the user identified with vendor user ID, or with foreign vendor ID and foreign user ID
+  app.get(
+    ['/user/:vendorUserId/token', '/foreign-user/:vendorId/:vendorUserId/token'],
+    authorizeUserOperation('token'),
+    lookupUser,
+    async (req, res) => {
+      let vendorToken;
+      try {
+        vendorToken = await connector.ensureAccessToken(req.fusebit, req.params.userContext);
+      } catch (e) {
+        Sdk.debug('ERROR OBTAINING ACCESS TOKEN', req.params.vendorUserId, e.stack || e.message || e);
+        return httpError(res, 502, `Unable to obtain access token for user ${req.params.vendorUserId}: ${e.message}`);
+      }
+      res.json(vendorToken);
+    }
+  );
+
+  // Delete the user identified with vendor user ID, or with foreign vendor ID and foreign user ID
+  app.delete(
+    ['/user/:vendorUserId', '/foreign-user/:vendorId/:vendorUserId'],
+    authorizeUserOperation(),
+    async (req, res) => {
+      await connector.deleteUser(req.fusebit, req.params.vendorUserId, req.params.vendorId);
+      res.status(204);
+      res.end();
+    }
+  );
+
   // /configure - initiate a new authorization transaction in the browser
   // /callback - process OAuth callback.
   app.get(['/configure', '/callback'], async (req, res) => {
@@ -50,50 +131,7 @@ exports.createApp = (connector) => {
         res.set(h, response.headers[h]);
       }
     }
-    if (response.body) {
-      res.send(response.body);
-    } else {
-      res.end();
-    }
-  });
-
-  app.get('/user/:vendorUserId/token', authorizeVendorUserOperation, async (req, res) => {
-    const userContext = await connector.getUser(req.fusebit, req.params.vendorUserId);
-    if (!userContext) {
-      return httpError(res, 404, `User ${req.params.vendorUserId} not found`);
-    }
-    let vendorToken;
-    try {
-      vendorToken = await connector.ensureAccessToken(req.fusebit, userContext);
-    } catch (e) {
-      Sdk.debug('ERROR OBTAINING ACCESS TOKEN', req.params.vendorUserId, e.stack || e.message || e);
-      return httpError(res, 502, `Unable to obtain access token for user ${req.params.vendorUserId}: ${e.message}`);
-    }
-    res.json(vendorToken);
-  });
-
-  app.get('/user/:vendorUserId', authorizeVendorUserOperation, async (req, res) => {
-    const userContext = await connector.getUser(req.fusebit, req.params.vendorUserId);
-    if (!userContext) {
-      return httpError(res, 404, `User ${req.params.vendorUserId} not found`);
-    } else {
-      return res.json(userContext);
-    }
-  });
-
-  app.get('/foreign-user/:vendorId/:vendorUserId', authorizeForeignVendorUserOperation, async (req, res) => {
-    const userContext = await connector.getUser(req.fusebit, req.params.vendorUserId, req.params.vendorId);
-    if (!userContext) {
-      return httpError(res, 404, `User ${req.params.vendorUserId} of OAuth provider ${req.params.vendorId} not found`);
-    } else {
-      return res.json(userContext);
-    }
-  });
-
-  app.delete('/user/:vendorUserId', authorizeVendorUserOperation, async (req, res) => {
-    await connector.deleteUser(req.fusebit, req.params.vendorUserId);
-    res.status(204);
-    res.end();
+    response.body ? res.send(response.body) : res.end();
   });
 
   connector.onCreate(app);

--- a/lib/connector/authorize.html
+++ b/lib/connector/authorize.html
@@ -83,7 +83,7 @@
 
           return (
               <Dialog open={true} fullWidth maxWidth="sm" disableBackdropClick disableEscapeKeyDown>
-                  <DialogTitle>Creating <strong>##vendorName##</strong> connector</DialogTitle>
+                  <DialogTitle><strong>##vendorName##</strong> authorization</DialogTitle>
                   <DialogContent>
                       <DialogContentText>The integration requires access to data in your ##vendorName## account. Please proceed to the next step to authorize access.</DialogContentText>
                   </DialogContent>

--- a/lib/manager/template/VendorOAuthConnector.js
+++ b/lib/manager/template/VendorOAuthConnector.js
@@ -143,9 +143,23 @@ class VendorOAuthConnector extends OAuthConnector {
    * saveUser, for example Fusebit functions.
    * @param {FusebitContext} fusebitContext The Fusebit context
    * @param {string} vendorUserId The vendor user id
+   * @param {string} vendorId If specified, vendorUserId represents the identity of the user in another system.
+   * The vendorId must correspond to an entry in userContext.foreignOAuthIdentities.
    */
-  async deleteUser(fusebitContext, vendorUserId) {
-    await super.deleteUser(fusebitContext, vendorUserId);
+  async deleteUser(fusebitContext, vendorUserId, vendorId) {
+    await super.deleteUser(fusebitContext, vendorUserId, vendorId);
+  }
+
+  /**
+   * Gets the health status of the user
+   * @param {FusebitContext} fusebitContext The Fusebit context of the request
+   * @param {*} userContext The user context representing the vendor's user. Contains vendorToken and vendorUserProfile, representing responses
+   * from getAccessToken and getUserProfile, respectively.
+   */
+  async getHealth(fusebitContext, userContext) {
+    // Perform any application-specific checks in the user represented by userContext and return an object with 'status'
+    // and optionally 'body' properties.
+    return { status: 200 };
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusebit/oauth-connector",
-  "version": "1.1.0-pre-1",
+  "version": "1.1.0",
   "description": "Fusebit Connector for OAuth",
   "main": "lib/index.js",
   "license": "MIT",

--- a/test/connector.test.js
+++ b/test/connector.test.js
@@ -16,6 +16,9 @@ const Url = require('url');
 
 const profile = getCredentials();
 
+const vendorId = 'foobar';
+const vendorUserId = 'u123';
+
 const configureCtx = createCtx(
   {
     query: {
@@ -29,8 +32,8 @@ const configureCtx = createCtx(
           boundaryId: testBoundaryId,
           functionId: testFunctionId2,
           templateName: 'test-template-name',
-          foobar_oauth_user_id: 'u123',
-          foobar_oauth_connector_base_url: 'https://idontexist',
+          [`${vendorId}_oauth_user_id`]: vendorUserId,
+          [`${vendorId}_oauth_connector_base_url`]: 'https://idontexist',
         })
       ).toString('base64'),
     },
@@ -115,6 +118,96 @@ const getTokenCtx = createCtx(
   }
 );
 
+const getForeignTokenCtx = createCtx(
+  {
+    configuration: {
+      vendor_oauth_authorization_url: 'https://idp.com/authorize',
+      vendor_oauth_token_url: 'https://idp.com/token',
+      vendor_oauth_scope: 'sample-scope',
+      vendor_oauth_audience: 'sample-audience',
+      vendor_oauth_client_id: '123',
+      vendor_oauth_client_secret: '456',
+      vendor_oauth_extra_params: 'sample-extra-param=12',
+      vendor_name: 'Contoso',
+      vendor_prefix: 'contoso',
+      fusebit_allowed_return_to: '*',
+    },
+    caller: {
+      permissions: {
+        allow: [
+          {
+            action: '*',
+            resource: '/',
+          },
+        ],
+      },
+    },
+  },
+  {
+    path: `/foreign-user/${vendorId}/${vendorUserId}/token`,
+  }
+);
+
+const getHealthCtx = createCtx(
+  {
+    configuration: {
+      vendor_oauth_authorization_url: 'https://idp.com/authorize',
+      vendor_oauth_token_url: 'https://idp.com/token',
+      vendor_oauth_scope: 'sample-scope',
+      vendor_oauth_audience: 'sample-audience',
+      vendor_oauth_client_id: '123',
+      vendor_oauth_client_secret: '456',
+      vendor_oauth_extra_params: 'sample-extra-param=12',
+      vendor_name: 'Contoso',
+      vendor_prefix: 'contoso',
+      fusebit_allowed_return_to: '*',
+    },
+    caller: {
+      permissions: {
+        allow: [
+          {
+            action: '*',
+            resource: '/',
+          },
+        ],
+      },
+    },
+  },
+  {
+    path: `/user/789/health`,
+  }
+);
+
+const getForeignHealthCtx = createCtx(
+  {
+    configuration: {
+      vendor_oauth_authorization_url: 'https://idp.com/authorize',
+      vendor_oauth_token_url: 'https://idp.com/token',
+      vendor_oauth_scope: 'sample-scope',
+      vendor_oauth_audience: 'sample-audience',
+      vendor_oauth_client_id: '123',
+      vendor_oauth_client_secret: '456',
+      vendor_oauth_extra_params: 'sample-extra-param=12',
+      vendor_name: 'Contoso',
+      vendor_prefix: 'contoso',
+      fusebit_allowed_return_to: '*',
+    },
+    caller: {
+      permissions: {
+        allow: [
+          {
+            action: '*',
+            resource: '/',
+          },
+        ],
+      },
+    },
+  },
+  {
+    path: `/foreign-user/${vendorId}/${vendorUserId}/health`,
+  }
+);
+
 const getUserCtx = createCtx(
   {
     configuration: {
@@ -171,7 +264,7 @@ const getForeignUserCtx = createCtx(
     },
   },
   {
-    path: `/foreign-user/foobar/u123`,
+    path: `/foreign-user/${vendorId}/${vendorUserId}`,
   }
 );
 
@@ -237,6 +330,37 @@ const deleteUserCtx = createCtx(
   },
   {
     path: `/user/789`,
+  }
+);
+
+const deleteForeignUserCtx = createCtx(
+  {
+    method: 'DELETE',
+    configuration: {
+      vendor_oauth_authorization_url: 'https://idp.com/authorize',
+      vendor_oauth_token_url: 'https://idp.com/token',
+      vendor_oauth_scope: 'sample-scope',
+      vendor_oauth_audience: 'sample-audience',
+      vendor_oauth_client_id: '123',
+      vendor_oauth_client_secret: '456',
+      vendor_oauth_extra_params: 'sample-extra-param=12',
+      vendor_name: 'Contoso',
+      vendor_prefix: 'contoso',
+      fusebit_allowed_return_to: '*',
+    },
+    caller: {
+      permissions: {
+        allow: [
+          {
+            action: '*',
+            resource: '/',
+          },
+        ],
+      },
+    },
+  },
+  {
+    path: `/foreign-user/${vendorId}/${vendorUserId}`,
   }
 );
 
@@ -392,7 +516,7 @@ describe('connector', () => {
     expect(response.body.data.vendorUserProfile).toBeDefined();
     expect(response.body.data.foreignOAuthIdentities).toBeDefined();
     expect(response.body.data.foreignOAuthIdentities.foobar).toBeDefined();
-    expect(response.body.data.foreignOAuthIdentities.foobar.userId).toBe('u123');
+    expect(response.body.data.foreignOAuthIdentities.foobar.userId).toBe(vendorUserId);
     expect(response.body.data.foreignOAuthIdentities.foobar.connectorBaseUrl).toBe('https://idontexist');
     expect(response.body.data.foo).toBe('bar');
     expect(response.body.data.dataPassedToBindUser).toMatchObject(
@@ -405,14 +529,14 @@ describe('connector', () => {
     response = await getStorage(
       testBoundaryId,
       testFunctionId1,
-      oAuthConnector._getStorageIdForVendorUser('u123', 'foobar')
+      oAuthConnector._getStorageIdForVendorUser(vendorUserId, vendorId)
     );
     expect(response.status).toBe(200);
     expect(response.body).toBeDefined();
     expect(response.body.data).toBeDefined();
     expect(response.body.data.vendorUserId).toBe(data.contoso_oauth_user_id);
     // Validate getUser works for the foreign user
-    const user1 = await oAuthConnector.getUser(configureCtx, 'u123', 'foobar');
+    const user1 = await oAuthConnector.getUser(configureCtx, vendorUserId, vendorId);
     expect(user1).toMatchObject(user);
     // Validate ensureAccessToken works for the connector user
     response = await oAuthConnector.ensureAccessToken(configureCtx, user);
@@ -422,7 +546,7 @@ describe('connector', () => {
     expect(response.expires_at).toBeDefined();
     // Validate ensureAccessToken throws for foreign user
     try {
-      await oAuthConnector.ensureAccessToken(configureCtx, user, 'foobar');
+      await oAuthConnector.ensureAccessToken(configureCtx, user, vendorId);
       throw new Error('Passed');
     } catch (e) {
       expect(e.message).toMatch(/ENOTFOUND idontexist/);
@@ -438,7 +562,7 @@ describe('connector', () => {
     response = await getStorage(
       testBoundaryId,
       testFunctionId1,
-      oAuthConnector._getStorageIdForVendorUser('u123', 'foobar')
+      oAuthConnector._getStorageIdForVendorUser(vendorUserId, vendorId)
     );
     expect(response.status).toBe(404);
   });
@@ -498,12 +622,12 @@ describe('connector', () => {
     response = await getStorage(
       testBoundaryId,
       testFunctionId1,
-      oAuthConnector._getStorageIdForVendorUser('u123', 'foobar')
+      oAuthConnector._getStorageIdForVendorUser(vendorUserId, vendorId)
     );
     expect(response.status).toBe(404);
   });
 
-  test('The /user/:vendorUserId/token endpoint returns access token', async () => {
+  test('The /user/:vendorUserId/token and /foreign-user/:vendorId/:vendorUserId/token endpoints return access token', async () => {
     const { VendorOAuthConnector } = require('../lib/manager/template/VendorOAuthConnector');
     class TestOAuthConnector extends VendorOAuthConnector {
       async getAuthorizationPageHtml(fusebitContext, authorizationUrl) {
@@ -519,7 +643,6 @@ describe('connector', () => {
         return { id: '789' };
       }
     }
-    const oAuthConnector = new TestOAuthConnector();
     const handler = connector.createOAuthConnector(new TestOAuthConnector());
     let ctx = configureCtx;
     // Initiate the authorization transaction only to extract the 'state' parameter to pass to /callback later
@@ -537,10 +660,59 @@ describe('connector', () => {
     response = await handler(ctx);
     expect(response.status).toBe(200);
     expect(typeof response.body).toBe('string');
-    const body = JSON.parse(response.body);
+    let body = JSON.parse(response.body);
     expect(body.access_token).toBe('access-token:abc');
     expect(body.expires_in).toBe(10000);
     expect(body.expires_at).toBeDefined();
+    // Get the current access token for the logged in user using foreign user id
+    ctx = getForeignTokenCtx;
+    response = await handler(ctx);
+    expect(response.status).toBe(200);
+    expect(typeof response.body).toBe('string');
+    body = JSON.parse(response.body);
+    expect(body.access_token).toBe('access-token:abc');
+    expect(body.expires_in).toBe(10000);
+    expect(body.expires_at).toBeDefined();
+  });
+
+  test('The /user/:vendorUserId/health and /foreign-user/:vendorId/:vendorUserId/health endpoints return user health', async () => {
+    const { VendorOAuthConnector } = require('../lib/manager/template/VendorOAuthConnector');
+    class TestOAuthConnector extends VendorOAuthConnector {
+      async getAuthorizationPageHtml(fusebitContext, authorizationUrl) {
+        return undefined;
+      }
+      async getAccessToken(fusebitContext, authorizationCode, redirectUri) {
+        return {
+          access_token: `access-token:${authorizationCode}`,
+          expires_in: 10000,
+        };
+      }
+      async getUserProfile(tokenContext) {
+        return { id: '789' };
+      }
+    }
+    const handler = connector.createOAuthConnector(new TestOAuthConnector());
+    let ctx = configureCtx;
+    // Initiate the authorization transaction only to extract the 'state' parameter to pass to /callback later
+    let response = await handler(ctx);
+    expect(response.status).toBe(302);
+    expect(response.headers).toBeDefined();
+    expect(typeof response.headers.location).toBe('string');
+    let url = Url.parse(response.headers.location, true);
+    expect(url.query.state).toBeDefined();
+    ctx = callbackCtx(url.query.state);
+    response = await handler(ctx);
+    expect(response.status).toBe(302);
+    // Get the current access token for the logged in user
+    ctx = getHealthCtx;
+    response = await handler(ctx);
+    expect(response.status).toBe(200);
+    expect(response.body).toBe('');
+    // Get the current access token for the logged in user using foreign user id
+    ctx = getForeignHealthCtx;
+    response = await handler(ctx);
+    expect(response.status).toBe(200);
+    expect(response.body).toBe('');
   });
 
   test('The GET /user/:vendorUserId endpoint returns user data', async () => {
@@ -559,7 +731,6 @@ describe('connector', () => {
         return { id: '789' };
       }
     }
-    const oAuthConnector = new TestOAuthConnector();
     const handler = connector.createOAuthConnector(new TestOAuthConnector());
     let ctx = configureCtx;
     // Initiate the authorization transaction only to extract the 'state' parameter to pass to /callback later
@@ -577,7 +748,7 @@ describe('connector', () => {
     response = await handler(ctx);
     expect(response.status).toBe(200);
     expect(typeof response.body).toBe('string');
-    const body = JSON.parse(response.body);
+    let body = JSON.parse(response.body);
     expect(body.status).toBe('authenticated');
     expect(body.vendorUserId).toBe('789');
     expect(body.vendorUserProfile).toMatchObject({ id: '789' });
@@ -633,7 +804,7 @@ describe('connector', () => {
     expect(body.vendorToken.expires_at).toBeDefined();
   });
 
-  test('The DELETE /user/:vendorUserId endpoint deletes the user', async () => {
+  test('The DELETE /user/:vendorUserId and /foreign-user/:vendorId/:vendorUserId endpoints delete the user', async () => {
     const { VendorOAuthConnector } = require('../lib/manager/template/VendorOAuthConnector');
     class TestOAuthConnector extends VendorOAuthConnector {
       async getAuthorizationPageHtml(fusebitContext, authorizationUrl) {
@@ -659,11 +830,29 @@ describe('connector', () => {
     expect(typeof response.headers.location).toBe('string');
     let url = Url.parse(response.headers.location, true);
     expect(url.query.state).toBeDefined();
+
+    // Create user and validate is is deleted
     ctx = callbackCtx(url.query.state);
     response = await handler(ctx);
     expect(response.status).toBe(302);
     // Delete the user
     ctx = deleteUserCtx;
+    response = await handler(ctx);
+    expect(response.status).toBe(204);
+    // Validate storage content for the deleted user is deleted
+    response = await getStorage(testBoundaryId, testFunctionId1, oAuthConnector._getStorageIdForVendorUser('789'));
+    expect(response.status).toBe(404);
+    // Validate the GET user returns 404
+    ctx = getUserCtx;
+    response = await handler(ctx);
+    expect(response.status).toBe(404);
+
+    // Create user and validate is is deleted using foreign ID
+    ctx = callbackCtx(url.query.state);
+    response = await handler(ctx);
+    expect(response.status).toBe(302);
+    // Delete the user
+    ctx = deleteForeignUserCtx;
     response = await handler(ctx);
     expect(response.status).toBe(204);
     // Validate storage content for the deleted user is deleted


### PR DESCRIPTION
This adds support for health check, and also cleans up all the routes for consistency: 

GET /user/:vendorUserId
GET /user/:vendorUserId/token
GET /user/:vendorUserId/health
DELETE /user/:vendorUserId

GET /foreign-user/:vendorId/:vendorUserId
GET /foreign-user/:vendorId/:vendorUserId/token
GET /foreign-user/:vendorId/:vendorUserId/health
DELETE /foreign-user/:vendorId/:vendorUserId

GET /callback
GET /configure
